### PR TITLE
Add Bioconda installation badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PMDtools
-Compute postmortem damage patterns and decontaminate ancient genomes
+Compute postmortem damage patterns and decontaminate ancient genomes. 
+
+[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](http://bioconda.github.io/recipes/pmdtools/README.html)
 
 
 ## Description


### PR DESCRIPTION
This adds an installation badge to the readme with a cross-link to bioconda for easy installation.

