### PR TITLE
Change "DS:Z:" lookup, fixes #9

### DIFF
--- a/pmdtools.0.60.py
+++ b/pmdtools.0.60.py
@@ -344,9 +344,9 @@ for line in sys.stdin:
 		if reverse: continue
 
 	DSfield=False
-	if 'DS:Z:' in line:
+	if '\tDS:Z:' in line:
 		DSfield=True
-		PMDS= float(line.split('DS:Z:')[1].rstrip('\n').split()[0])
+		PMDS= float(line.split('\tDS:Z:')[1].rstrip('\n').split()[0])
 		LR=PMDS
 		#print PMDS
 	


### PR DESCRIPTION
This fixes the issue mentioned in #9 . By adding the tab character to the searched string for the "DS:Z:" matching, it ensures that this string is at the beginning of its own field and not inside other fields such as the base quality. 